### PR TITLE
fix: hits.linnk

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Current Projects:
 <details>
 <summary>Misc.</summary>
 <br>
-<img src="https://hits.link/hits?url=https%3A%2F%2Fgithub.com%2FRiceCX" />
+<img src="https://hits-app.vercel.app/hits?url=https%3A%2F%2Fgithub.com%2FRiceCX" />
 <img src="https://komarev.com/ghpvc/?username=RiceCX&color=blueviolet" />
     
 ![Metrics](https://metrics.lecoq.io/RiceCX?template=classic&base.header=0&base.activity=0&base.community=0&base.repositories=0&base.metadata=0&achievements=1&achievements.threshold=C&achievements.secrets=true&achievements.display=detailed&achievements.limit=0&config.timezone=America%2FLos_Angeles)


### PR DESCRIPTION
we've recently dropped the hits.link domain because the renewal price was $180, please use the updated/stable one :D!

sorry for the inconvenience!